### PR TITLE
Allow for custom delimiters

### DIFF
--- a/src/jsonresolver.js
+++ b/src/jsonresolver.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 
 function escape(delimiterObject) {
     function escapeReplace(str) {
-        return str.replace(/([\[\]\{\}\(\)\$])/g, '\\\$1');
+        return str.replace(/([\[\]\{\}\(\)\$\*])/g, '\\\$1');
     }
 
     delimiterObject.first = escapeReplace(delimiterObject.first);
@@ -11,7 +11,7 @@ function escape(delimiterObject) {
 
 function JSONResolver( options ) {
 
-    var del = { first: '%', last: '%' };
+    var del = { first: '%', last: "%" };
     if (options && options.delimiter) {
         del = {
             first: options.delimiter.first || options.delimiter,

--- a/src/jsonresolver.js
+++ b/src/jsonresolver.js
@@ -1,8 +1,24 @@
 var _ = require('lodash');
 
+function escape(delimiterObject) {
+    function escapeReplace(str) {
+        return str.replace(/([\[\]\{\}\(\)\$])/g, '\\\$1');
+    }
+
+    delimiterObject.first = escapeReplace(delimiterObject.first);
+    delimiterObject.last = escapeReplace(delimiterObject.last);
+}
+
 function JSONResolver( options ) {
 
-    var delimiter = options && options.delimiter ? options.delimiter : '%';
+    var del = { first: '%', last: '%' };
+    if (options && options.delimiter) {
+        del = {
+            first: options.delimiter.first || options.delimiter,
+            last: options.delimiter.last || options.delimiter
+        };
+    }
+    escape(del);
 
     function resolveWithContext(jsonString, ctx) {
 
@@ -15,17 +31,17 @@ function JSONResolver( options ) {
         while (jsonString !== prevString) {
             prevString = jsonString;
 
-            re = new RegExp(delimiter+'([\\w\\d-_\\.]+)'+delimiter,'g');
+            re = new RegExp(del.first+'([\\w\\d-_\\.]+)'+del.last,'g');
             keys = jsonString.match(re);
 
             if (!keys) continue;
 
             keys.forEach(function(key) {
-                re = new RegExp(delimiter+'([\\w\\d-_\\.]+)'+delimiter);
+                re = new RegExp(del.first+'([\\w\\d-_\\.]+)'+del.last);
                 key = key.match(re)[1];
                 value = _.get(ctx, key);
                 if (value) {
-                    replaceString = delimiter + key + delimiter;
+                    replaceString = new RegExp(del.first+key+del.last);
                     jsonString = jsonString.replace(replaceString, value);
                 }
             });

--- a/test/jsonresolverSpec.js
+++ b/test/jsonresolverSpec.js
@@ -183,7 +183,7 @@ describe('JSON variable resolver', function () {
 });
 
 describe('Custom delimiters', function () {
-    
+
     it('should resolve when set', function () {
         var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: '&&'});
         var expected = { 'foo':'bar','baz':'luhrmann' },
@@ -215,6 +215,15 @@ describe('Custom delimiters', function () {
         var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: {first: '${', last: '}'}});
         var expected = { 'foo':'bar','baz':'luhrmann' },
                 json = { 'foo':'${a}','baz':'luhrmann' },
+                ctx = { 'a':'bar' };
+
+        expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);
+    });
+
+    it('should resolve silly regexp things', function () {
+        var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: '**'});
+        var expected = { 'foo':'bar','baz':'luhrmann' },
+                json = { 'foo':'**a**','baz':'luhrmann' },
                 ctx = { 'a':'bar' };
 
         expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);

--- a/test/jsonresolverSpec.js
+++ b/test/jsonresolverSpec.js
@@ -182,6 +182,18 @@ describe('JSON variable resolver', function () {
     });
 });
 
+describe('Custom delimiters', function () {
+    var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: '&&'});
+    
+    it('should resolve when set', function () {
+        var expected = { 'foo':'bar','baz':'luhrmann' },
+                json = { 'foo':'&&a&&','baz':'luhrmann' },
+                ctx = { 'a':'bar' };
+
+        expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);
+    });
+});
+
 describe('chaining', function() {
     describe('chain a single resolve', function () {
         it('should resolve normally, returning after calling value()', function () {

--- a/test/jsonresolverSpec.js
+++ b/test/jsonresolverSpec.js
@@ -183,11 +183,38 @@ describe('JSON variable resolver', function () {
 });
 
 describe('Custom delimiters', function () {
-    var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: '&&'});
     
     it('should resolve when set', function () {
+        var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: '&&'});
         var expected = { 'foo':'bar','baz':'luhrmann' },
                 json = { 'foo':'&&a&&','baz':'luhrmann' },
+                ctx = { 'a':'bar' };
+
+        expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);
+    });
+
+    it('should resolve open and closed style delimiters', function () {
+        var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: {first: '[[', last: ']]'}});
+        var expected = { 'foo':'bar','baz':'luhrmann' },
+                json = { 'foo':'[[a]]','baz':'luhrmann' },
+                ctx = { 'a':'bar' };
+
+        expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);
+    });
+
+    it('should resolve reserved regex characters', function () {
+        var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: '$$'});
+        var expected = { 'foo':'bar','baz':'luhrmann' },
+                json = { 'foo':'$$a$$','baz':'luhrmann' },
+                ctx = { 'a':'bar' };
+
+        expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);
+    });
+
+    it('should resolve bash style things', function () {
+        var jsonResolverDelimiter = require('../src/jsonResolver')({delimiter: {first: '${', last: '}'}});
+        var expected = { 'foo':'bar','baz':'luhrmann' },
+                json = { 'foo':'${a}','baz':'luhrmann' },
                 ctx = { 'a':'bar' };
 
         expect(jsonResolverDelimiter.resolve(json, ctx)).toEqual(expected);


### PR DESCRIPTION
There's still an issue where what people _would_ use as a delimiter is
probably already a protexted regexp character... And it wouldn't match
things that close, a la handlebars `{{}}`
